### PR TITLE
Update jquery.i18n.properties.js

### DIFF
--- a/jquery.i18n.properties.js
+++ b/jquery.i18n.properties.js
@@ -95,8 +95,11 @@
             if (settings.language.length >= 5) {
                 var longCode = settings.language.substring(0, 5);
                 longFileName = settings.path + file + '_' + longCode + '.properties';
+                filenames = [defaultFileName, shortFileName, longFileName];
+            } else {
+                filenames = [defaultFileName, shortFileName];
             }
-            loadAndParseFiles([defaultFileName, shortFileName, longFileName], settings);
+            loadAndParseFiles(filenames, settings);
         });
 
         // call callback


### PR DESCRIPTION
If settings.language.length was not >= 5 the longFileName variable would not be initialized and undefined would be passed onto the loadAndParseFiles function resulting in an exception.  Added a simple else to not pass in the undefined variable as part of the filenames array.